### PR TITLE
Fix: failing response on directory create

### DIFF
--- a/src/data.coffee
+++ b/src/data.coffee
@@ -82,6 +82,7 @@ class Dir extends Data
     content =
         name: @basename()
     headers =
+      'Accept': 'application/json'
       'Content-Type': 'application/json'
     @client.req('/v1/data/' + @parent().data_path, 'POST', JSON.stringify(content), headers, callback)
 


### PR DESCRIPTION
### Issue
Request to `create` directory does not have 'Accept' header and a server does not send `content-type` header in the response.

As a result code src/algorithmia.coffee at L:70 fails with error `TypeError: Cannot read property 'startsWith' of undefined`:
```javascript
if ct.startsWith('application/json')
```

### Changes
`Accept` header added to request to create directory

Please add `content-type` header to response on directory create.
